### PR TITLE
No-op release to fix auto docker publishing

### DIFF
--- a/.roxanne.yml
+++ b/.roxanne.yml
@@ -10,8 +10,11 @@ stages:
     - ./scripts/test.sh
   release:
     image: ruby:3.2
+    only:
+    - main
+  publish:
+    image: docker:latest
     scripts:
-    - ./scripts/release.sh
     - ./scripts/publish.sh
     only:
     - main

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bullion (0.4.0)
+    bullion (0.4.1)
       httparty (~> 0.21)
       json (~> 2.6)
       jwt (~> 2.7)

--- a/lib/bullion/version.rb
+++ b/lib/bullion/version.rb
@@ -4,6 +4,6 @@ module Bullion
   VERSION = [
     0, # major
     4, # minor
-    0 # patch
+    1 # patch
   ].join(".")
 end


### PR DESCRIPTION
Cutting a new release to (hopefully) fix automatic docker publishing.