### PR TITLE
Making bullion certbot compatible

### DIFF
--- a/lib/bullion/helpers/service.rb
+++ b/lib/bullion/helpers/service.rb
@@ -6,11 +6,38 @@ module Bullion
     module Service
       def add_acme_headers(nonce, additional: {})
         headers["Replay-Nonce"] = nonce
-        headers["Link"] = "<#{uri("/directory")}>;rel=\"index\""
+        add_link_relation("index", uri("/directory"))
 
         additional.each do |name, value|
           headers[name.to_s] = value.to_s
         end
+      end
+
+      def add_link_relation(type, value)
+        cur = link_headers_to_hash(headers["Link"])
+        cur[type] = value
+        headers["Link"] = hashed_links_to_link_headers(cur)
+      end
+
+      private
+
+      def link_headers_to_hash(values_string)
+        return {} unless values_string&.length&.positive?
+
+        values_string.split(",").to_h do |relation|
+          raw_value, raw_name = relation.split(";")
+          value = /^<(.+)>$/.match(raw_value)[1]
+          name = /^rel="(.+)"$/.match(raw_name)[1]
+          [name, value]
+        end
+      end
+
+      def hashed_links_to_link_headers(hash)
+        hash.reduce([]) do |acc, data|
+          name = "rel=\"#{data[0]}\""
+          value = "<#{data[1]}>"
+          acc << [value, name].join(";")
+        end.join(",")
       end
     end
   end

--- a/lib/bullion/version.rb
+++ b/lib/bullion/version.rb
@@ -3,7 +3,7 @@
 module Bullion
   VERSION = [
     0, # major
-    4, # minor
-    3 # patch
+    5, # minor
+    0 # patch
   ].join(".")
 end


### PR DESCRIPTION
Resolves #33.

Certbot requires the `up` Link relation header in the server response for verification of a challenge. It also requires replay nonces when retrieving certificates. Both of these are addressed, plus the authorization itself is now properly marked as `valid` when the challenge is successful.