### PR TITLE
Certbot thumbprint requires sorted key params

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bullion (0.6.1)
+    bullion (0.7.0)
       dry-configurable (~> 1.1)
       httparty (~> 0.21)
       json (~> 2.6)

--- a/lib/bullion/challenge_client.rb
+++ b/lib/bullion/challenge_client.rb
@@ -22,6 +22,8 @@ module Bullion
       tries = 0
       success = false
 
+      challenge.update!(status: "processing")
+
       benchtime = Benchmark.realtime do
         until success || tries >= retries
           tries += 1
@@ -39,6 +41,8 @@ module Bullion
       unless success
         LOGGER.info "Failed to validate #{type} #{identifier}"
         challenge.status = "invalid"
+        challenge.authorization.update!(status: "invalid")
+        challenge.authorization.order.update!(status: "invalid")
       end
 
       challenge.save

--- a/lib/bullion/models/challenge.rb
+++ b/lib/bullion/models/challenge.rb
@@ -24,7 +24,7 @@ module Bullion
 
       def thumbprint
         cipher = OpenSSL::Digest.new("SHA256")
-        digest = cipher.digest(authorization.order.account.public_key.to_json)
+        digest = cipher.digest(lexicographically_ordered_public_key.to_json)
         Base64.urlsafe_encode64(digest).sub(/[\s=]*\z/, "")
       end
 
@@ -37,6 +37,13 @@ module Bullion
         end
 
         challenge_class.new(self)
+      end
+
+      private
+
+      def lexicographically_ordered_public_key
+        jwk = authorization.order.account.public_key
+        [["e", jwk["e"]], ["kty", jwk["kty"]], ["n", jwk["n"]]].to_h
       end
     end
   end

--- a/lib/bullion/services/ca.rb
+++ b/lib/bullion/services/ca.rb
@@ -345,6 +345,8 @@ module Bullion
         # Oddly enough, cert-manager uses a GET request for retrieving Challenge info
         challenge.client.attempt unless @json_body && @json_body[:payload] == ""
 
+        challenge.reload
+
         data = {
           type: challenge.acme_type,
           status: challenge.status,

--- a/lib/bullion/version.rb
+++ b/lib/bullion/version.rb
@@ -3,7 +3,7 @@
 module Bullion
   VERSION = [
     0, # major
-    6, # minor
-    2 # patch
+    7, # minor
+    0 # patch
   ].join(".")
 end


### PR DESCRIPTION
Closes #35

It turns out that the public key params are not always provided in the same order used by certbot to generate the thumbprint. This commit sorts the params before generating the thumbprint based on the lexicographical order specified in [RFC7638](https://datatracker.ietf.org/doc/html/rfc7638#section-3.3)