### PR TITLE
Making Docker nonroot user numeric

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ WORKDIR /app
 
 RUN gem install bullion.gem
 
-USER nobody
+# nobody user is uid 65534
+USER 65534
 
 EXPOSE 9292
 


### PR DESCRIPTION
When run in Kubernetes with `runAsNonRoot: true`, the Docker `USER` directive must be numeric.