### PR TITLE
Loading required bigdecimal gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,6 +62,7 @@ end
 
 require "openssl"
 require "sqlite3"
+require "bigdecimal"
 require "trilogy"
 require "sinatra/activerecord/rake"
 

--- a/lib/bullion.rb
+++ b/lib/bullion.rb
@@ -7,6 +7,7 @@ require "securerandom"
 require "time"
 require "logger"
 require "openssl"
+require "bigdecimal"
 
 # External requirements
 require "benchmark"

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
 # Starts the server
-rake db:migrate
 itsi


### PR DESCRIPTION
When using Bullion with MySQL, bigdecimal now needs to be loaded explicitly.

Also moving DB migrations out of docker entrypoint. It is recommended that migrations are run in a dedicated init container or deployment.