### PR TITLE
feat: add EdDSA (Ed25519) JWT signature support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ PATH
       itsi (~> 0.2)
       json (~> 2.6)
       jwt (~> 2.7)
+      jwt-eddsa (~> 0.9)
       openssl (~> 3.0)
       prometheus-client (~> 4.2)
       sinatra (~> 3.1)
@@ -61,6 +62,7 @@ GEM
       concurrent-ruby (~> 1.0)
       logger
       zeitwerk (~> 2.6)
+    ed25519 (1.4.0)
     faraday (2.13.4)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -89,6 +91,10 @@ GEM
     json (2.13.2)
     jwt (2.10.2)
       base64
+    jwt-eddsa (0.9.0)
+      base64
+      ed25519
+      jwt (>= 2.9.0)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)

--- a/bullion.gemspec
+++ b/bullion.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "itsi",                 "~> 0.2"
   spec.add_dependency "json",                 "~> 2.6"
   spec.add_dependency "jwt",                  "~> 2.7"
+  spec.add_dependency "jwt-eddsa",            "~> 0.9"
   spec.add_dependency "openssl",              "~> 3.0"
   spec.add_dependency "prometheus-client",    "~> 4.2"
   spec.add_dependency "sinatra",              "~> 3.1"

--- a/lib/bullion.rb
+++ b/lib/bullion.rb
@@ -18,6 +18,8 @@ require "sinatra/custom_logger"
 require "trilogy"
 require "sinatra/activerecord"
 require "jwt"
+require "jwt/eddsa"
+require "ed25519"
 require "prometheus/client"
 require "httparty"
 

--- a/lib/bullion/acme/error.rb
+++ b/lib/bullion/acme/error.rb
@@ -34,6 +34,11 @@ module Bullion
         def acme_type = "badNonce"
       end
 
+      # ACME exception for bad/unsupported public keys
+      class BadPublicKey < Bullion::Acme::Error
+        def acme_type = "badPublicKey"
+      end
+
       # ACME exception for invalid contacts in accounts
       class InvalidContact < Bullion::Acme::Error
         def acme_type = "invalidContact"

--- a/lib/bullion/helpers/acme.rb
+++ b/lib/bullion/helpers/acme.rb
@@ -41,10 +41,11 @@ module Bullion
           JWT.decode(jwt_data, compat_public_key, true, { algorithm: @header_data["alg"] })
         else
           digest = digest_from_alg(@header_data["alg"])
+          alg = @header_data["alg"].downcase
 
-          sig = if @header_data["alg"].downcase.start_with?("es")
+          sig = if alg.start_with?("es")
                   ecdsa_sig_to_der(signature)
-                elsif @header_data["alg"].downcase.start_with?("rs")
+                elsif alg.start_with?("rs") || alg == "eddsa"
                   Base64.urlsafe_decode64(signature)
                 end
 

--- a/lib/bullion/helpers/ssl.rb
+++ b/lib/bullion/helpers/ssl.rb
@@ -72,9 +72,10 @@ module Bullion
           Ed25519::VerifyKey.new(x)
         when "Ed448"
           # Ed448 not currently supported by the ed25519 gem
-          raise "Ed448 is not currently supported"
+          raise Bullion::Acme::Errors::BadPublicKey,
+                "EdDSA with Ed448 is not supported; only Ed25519 is supported"
         else
-          raise "Unsupported EdDSA curve: #{curve}"
+          raise Bullion::Acme::Errors::BadPublicKey, "Unsupported EdDSA curve: #{curve}"
         end
       end
 

--- a/lib/bullion/models/challenge.rb
+++ b/lib/bullion/models/challenge.rb
@@ -50,7 +50,17 @@ module Bullion
 
       def lexicographically_ordered_public_key
         jwk = authorization.order.account.public_key
-        [["e", jwk["e"]], ["kty", jwk["kty"]], ["n", jwk["n"]]].to_h
+        case jwk["kty"]
+        when "RSA"
+          [["e", jwk["e"]], ["kty", jwk["kty"]], ["n", jwk["n"]]].to_h
+        when "EC"
+          [["crv", jwk["crv"]], ["kty", jwk["kty"]], ["x", jwk["x"]], ["y", jwk["y"]]].to_h
+        when "OKP"
+          [["crv", jwk["crv"]], ["kty", jwk["kty"]], ["x", jwk["x"]]].to_h
+        else
+          # Fallback for unknown types
+          jwk.sort.to_h
+        end
       end
     end
   end

--- a/spec/bullion/models/account_spec.rb
+++ b/spec/bullion/models/account_spec.rb
@@ -49,5 +49,28 @@ RSpec.describe Bullion::Models::Account do
         expect(order.errors).to be_empty
       end
     end
+
+    describe "with EdDSA keys" do
+      let(:account_key) { eddsa_key("Ed25519") }
+
+      let(:public_key_hash) { eddsa_public_key_hash(account_key, "Ed25519") }
+
+      let(:basic_account) do
+        user_email = "ed.jones@example.com"
+        described_class.new(
+          tos_agreed: true,
+          contacts: [user_email],
+          public_key: public_key_hash
+        )
+      end
+
+      it("creates new accounts") { expect(basic_account.save).to be_truthy }
+
+      it "allows starting new orders" do
+        basic_account.save
+        order = basic_account.start_order(identifiers: ["test.example.com"])
+        expect(order.errors).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
Add support for EdDSA algorithm with Ed25519 keys for ACMEv2 JWT signatures per RFC 8037 and RFC 8555.

## Changes
- Add jwt-eddsa and ed25519 gem dependencies
- Implement EdDSA key parsing and verification  
- Add test coverage for Ed25519 account creation and order submission
- Update helpers to handle OKP key type
- Fix thumbprint calculation for EdDSA keys

## Testing
- ✅ EdDSA account registration works
- ✅ EdDSA order submission works

## Notes
- Only Ed25519 is supported (Ed448 not needed for ACMEv2)
- Uses `jwt-eddsa` gem for JWT verification

Resolves #3