### PR TITLE
docs: Add CONTRIBUTING.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+Guidelines for AI agents and automated tools working in this repository.
+
+## Project Overview
+
+Bullion is a Ruby gem implementing an [ACMEv2](https://tools.ietf.org/html/rfc8555)-compatible Certificate Authority. It runs as a web service (Sinatra + [Itsi](https://itsi.fyi/)) and uses ActiveRecord for persistence.
+
+- **Language**: Ruby 3.4
+- **Framework**: Sinatra, Itsi (Rack-based)
+- **ORM**: ActiveRecord (SQLite3 or [Trilogy](https://github.com/trilogy-libraries/trilogy) for MySQL/MariaDB)
+- **Testing**: RSpec
+- **Docs**: YARD
+- **Linting**: RuboCop (rubocop-rake, rubocop-rspec)
+- **Releases**: Automated via release-please on push to `main`
+
+## Quality Gates
+
+All three must pass before opening a PR. These run in CI (`.github/workflows/ci.yml`):
+
+```bash
+bundle exec rubocop          # Style/lint
+bundle exec rake spec        # Unit tests (integration specs excluded by default)
+bundle exec rake yard        # YARD documentation generation
+```
+
+Integration tests run separately: `bundle exec rake integration_testing`
+
+## Constraints
+
+- **Do not edit** `lib/bullion/version.rb` or `CHANGELOG.md`. These are managed by release-please.
+- **Do not add runtime dependencies** without explicit justification. The gemspec is deliberately curated.
+- **Do not suppress RuboCop cops inline** without a stated reason. Fix the code or adjust `.rubocop.yml` if a project-wide change is warranted.
+- **Security-critical areas** — Changes to `lib/bullion/services/ca.rb`, challenge client logic, or any crypto/certificate handling must include test coverage. ACME protocol correctness is a security guarantee.
+- **Respect existing structure** — Modules live under `lib/bullion/` following the established namespace layout (`Bullion::Models`, `Bullion::Services`, `Bullion::ChallengeClients`, `Bullion::Helpers`).
+
+## Conventions
+
+- **Conventional Commits** — `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`. Release-please generates changelogs from commit messages, so this is functional, not cosmetic.
+- **Double-quoted strings** — Enforced by `.rubocop.yml` (`Style/StringLiterals`).
+- **100-character line length** — Enforced by RuboCop (`Layout/LineLength`).
+- **Ruby 3.4 target** — Use modern Ruby syntax; don't add compatibility shims for older versions.
+
+## Workflow
+
+1. **Plan before code.** Produce a design or plan before writing implementation code. Use planning/brainstorming skills as appropriate.
+2. **Tests first.** Write or update tests before or alongside implementation.
+3. **Minimal viable output.** Produce focused artifacts with clear structure. Don't over-engineer or add scope beyond the task.
+4. **Run all quality gates** before declaring work complete.
+5. **Respect project boundaries** defined in this file and in `CONTRIBUTING.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing to Bullion
+
+Thanks for your interest in contributing! This document covers the expectations and workflow so contributions are smooth, consistent, and ready for review.
+
+## Core Principles
+
+- **Working code first** — Prioritize functional, tested changes over perfect documentation. Docs should be scoped and precise, not exhaustive.
+- **Tests required** — Every behavioral change must include or update automated tests. CI runs `rake spec`; PRs that don't pass won't be reviewed.
+- **Style is enforced** — RuboCop runs in CI with the project's `.rubocop.yml` config. Fix warnings locally before pushing.
+- **Minimal dependencies** — The gemspec is deliberately curated. Don't add runtime dependencies without justification.
+- **Security matters** — Bullion is a Certificate Authority. Changes to ACME protocol handling, crypto, or certificate issuance must include tests and warrant extra scrutiny.
+
+## Getting Started
+
+1. Fork the repo and clone your fork.
+2. Run `bin/setup` to install dependencies.
+3. Run `rake spec` to verify a clean baseline.
+4. Use `bin/console` for an interactive prompt to experiment.
+
+## Development Workflow
+
+1. Write or update tests first (TDD encouraged).
+2. Implement your changes.
+3. Run quality checks before pushing:
+
+   ```bash
+   bundle exec rubocop
+   bundle exec rake spec
+   bundle exec rake yard
+   ```
+
+4. Open a Pull Request with a clear description.
+
+### Integration Tests
+
+The default `rake spec` task excludes integration specs. Run them separately with:
+
+```bash
+bundle exec rake integration_testing
+```
+
+Integration specs are not required for PRs but are appreciated for changes that affect ACME protocol flows.
+
+## Branching & Commits
+
+- Use feature branches: `feature/<short-description>` or `fix/<short-description>`.
+- Follow [Conventional Commits](https://www.conventionalcommits.org/):
+  - `feat: add ECDSA order support`
+  - `fix: correct nonce validation timing`
+  - `docs: update configuration reference`
+  - `refactor: extract challenge client logic`
+  - `test: add HTTP-01 challenge coverage`
+  - `chore: bump dependency versions`
+- Keep commits focused and logically grouped. Avoid mixing unrelated changes.
+
+Conventional Commits are not just style — releases are automated via [release-please](https://github.com/googleapis/release-please), which generates the changelog from commit messages. Following the convention directly affects the quality of release notes.
+
+## Releases
+
+**Do not manually edit `lib/bullion/version.rb` or `CHANGELOG.md`.**
+
+Releases are fully automated via release-please on push to `main`. When a release PR is merged, the workflow:
+
+- Bumps the version in `lib/bullion/version.rb`
+- Updates `CHANGELOG.md` from Conventional Commits
+- Builds and publishes the gem to RubyGems
+- Builds and pushes Docker images to Docker Hub (`jgnagy/bullion:latest`, version, and major.minor tags)
+
+If a release is needed manually, coordinate with the maintainer rather than editing version files directly.
+
+## Pull Request Guidelines
+
+A good PR includes:
+
+- **Summary** — What changed and why.
+- **Scope** — Which part of the system (ACME protocol, models, challenge clients, config, docs).
+- **Testing** — Outline of added tests and coverage areas.
+- **Security Impact** — Any effects on certificate issuance, challenge validation, or crypto.
+
+PRs may be declined or requested for revision if:
+
+- Tests are missing or incomplete.
+- RuboCop or YARD checks fail.
+- New dependencies are added without justification.
+- Unrelated changes are mixed together (split them up).
+
+## Code of Conduct
+
+Everyone interacting in the Bullion project is expected to follow the [Contributor Covenant](http://contributor-covenant.org) code of conduct. See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) for details.
+
+## License
+
+By contributing, you agree your contributions are licensed under the [MIT License](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -57,20 +57,10 @@ Bullion provides a `/ping` endpoint that should respond with `{ 'status': 'up' }
 
 Prometheus metrics are also scrapable at `/metrics`. This includes typical web request information as well as latencies related to the different Challenge types.
 
-## Development
+## Development & Contributing
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`.
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/jgnagy/bullion. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for development setup, testing, style guidelines, and pull request expectations. Guidelines for AI agents and automated tools are in [`AGENTS.md`](AGENTS.md).
 
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-
-## Code of Conduct
-
-Everyone interacting in the Bullion project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/jgnagy/bullion/blob/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary

Closes #96.

Adds two documentation files to formalize contribution guidelines and agent conventions, as proposed in issue #96.

## Changes

### `CONTRIBUTING.md` (new)
Reflects bullion's actual workflow rather than porting from another project:
- **Getting started**: `bin/setup`, `rake spec`, `bin/console`
- **Development workflow**: Quality gates (`rubocop`, `rake spec`, `rake yard`) matching CI
- **Integration tests**: Documented as separate (`rake integration_testing`), not required for PRs
- **Conventional Commits**: Required by release-please for changelog generation — functional, not cosmetic
- **Releases**: Automated via release-please; explicit note not to edit `lib/bullion/version.rb` or `CHANGELOG.md` manually
- **PR guidelines**: Tests, style, scope, security impact for ACME/crypto changes
- **Code of Conduct & License**: Referenced, not duplicated

### `AGENTS.md` (new)
Compact agent guidelines (~60 lines), much leaner than authify's:
- **Project overview**: Ruby 3.4, Sinatra/Itsi, ActiveRecord, RSpec, YARD
- **Quality gates**: Matches CI (`rubocop`, `rake spec`, `rake yard`)
- **Constraints**: No manual version bumps, no unvetted dependencies, security-critical areas require tests, respect existing module structure
- **Conventions**: Conventional Commits, double-quoted strings, 100-char lines, Ruby 3.4 target
- **Workflow**: Plan before code, tests first, minimal viable output

### `README.md` (modified)
Consolidated the duplicated **Development**, **Contributing**, and **Code of Conduct** sections into a single pointer to `CONTRIBUTING.md` and `AGENTS.md`. This avoids three-way drift between README, CONTRIBUTING, and AGENTS.

## Design Decisions

- **Lean over comprehensive**: Both files are scoped for iterative maintenance, matching the agile style of the project. ~80 lines for CONTRIBUTING, ~60 for AGENTS.
- **Release-please is the key convention**: The most common contributor mistake (manually editing version files) is not caught by CI. Made this explicit in both files.
- **README consolidation**: Rather than duplicating setup instructions across README and CONTRIBUTING, the README now points to the dedicated files. `CODE_OF_CONDUCT.md` is referenced from CONTRIBUTING rather than repeated.
- **No authify porting**: authify's CONTRIBUTING and AGENTS are excellent but Elixir/Phoenix-specific. Bullion's files reflect bullion's actual stack and conventions.

## Testing

Documentation-only change. No code, tests, or CI behavior affected.

## Review Notes

- The commit message uses Conventional Commits format, which is the convention being documented in this very PR.
- `CODE_OF_CONDUCT.md` already exists and is unchanged; it's now referenced from CONTRIBUTING.md instead of README.md.