### PR TITLE
fix: replace undefined CERT_VALIDITY_DURATION constant with config call

### DIFF
--- a/lib/bullion/helpers/acme.rb
+++ b/lib/bullion/helpers/acme.rb
@@ -174,7 +174,7 @@ module Bullion
         # don't allow nonsense certs
         raise Bullion::Acme::Errors::InvalidOrder unless nb < na
         # don't allow far-future certs
-        if nb > Time.now + (7 * 86_400) || na > Time.now + CERT_VALIDITY_DURATION
+        if nb > Time.now + (7 * 86_400) || na > Time.now + Bullion.config.ca.cert_validity_duration
           raise Bullion::Acme::Errors::InvalidOrder
         end
 

--- a/spec/bullion/services/ca_negative_spec.rb
+++ b/spec/bullion/services/ca_negative_spec.rb
@@ -360,6 +360,48 @@ RSpec.describe Bullion::Services::CA do
       end
     end
 
+    it "rejects orders with notAfter beyond the maximum validity duration" do
+      register_account
+      kid = last_response.headers["Location"]
+
+      get "/nonces"
+      nonce = last_response.headers["Replay-Nonce"]
+
+      jwk = {
+        typ: "JWT",
+        alg: "RS256",
+        kid:,
+        nonce:,
+        url: "/orders"
+      }.to_json
+      encoded_jwk = acme_base64(jwk)
+
+      now = Time.now
+      payload = {
+        identifiers: [{ "type" => "dns", "value" => "good.test.domain" }],
+        notBefore: (now + 86_400).iso8601,
+        notAfter: (now + (90 * 24 * 60 * 60) + 86_400).iso8601
+      }.to_json
+      encoded_payload = acme_base64(payload)
+      signature_data = "#{encoded_jwk}.#{encoded_payload}"
+
+      body = {
+        protected: encoded_jwk,
+        payload: encoded_payload,
+        signature: acme_sign(account_key, signature_data)
+      }.to_json
+
+      post "/orders", body, { "CONTENT_TYPE" => "application/jose+json" }
+
+      expect(last_response.status).to eq(400)
+      expect(last_response.headers["Content-Type"]).to \
+        eq("application/problem+json")
+
+      parsed_body = JSON.parse(last_response.body)
+      expect(parsed_body["type"]).to \
+        eq("urn:ietf:params:acme:error:invalidOrder")
+    end
+
     it "rejects finalization with CSR for wrong domain" do
       register_account
       kid = last_response.headers["Location"]


### PR DESCRIPTION
## Summary

Fixes a runtime `NameError` in `lib/bullion/helpers/acme.rb:177` where `CERT_VALIDITY_DURATION` was referenced as a bare Ruby constant but is only an environment variable name. The correct reference is `Bullion.config.ca.cert_validity_duration`.

## The Bug

When an ACME client submits an order with explicit `notBefore` and `notAfter` values (valid per RFC 8555 §7.1), the `validate_order_nb_and_na` method would raise:

```
NameError: uninitialized constant Bullion::Helpers::Acme::CERT_VALIDITY_DURATION
```

This caused a 500 error instead of a proper ACME error response.

## Root Cause

`CERT_VALIDITY_DURATION` appears as an env var name in `lib/bullion.rb:129` and is documented in `README.md`, but was never defined as a Ruby constant. The config value is accessible via `Bullion.config.ca.cert_validity_duration`.

## Changes

- **`lib/bullion/helpers/acme.rb`**: Replaced `CERT_VALIDITY_DURATION` with `Bullion.config.ca.cert_validity_duration`
- **`spec/bullion/services/ca_negative_spec.rb`**: Added test case that submits an order with `notBefore`/`notAfter` exceeding the maximum validity duration, verifying it returns a proper `invalidOrder` ACME error instead of crashing

## Testing

- ✅ `bundle exec rubocop` — no offenses
- ✅ `bundle exec rspec` — 116 examples, 0 failures (was 115; +1 new test)
- ✅ `bundle exec rake yard` — passes

Closes #101